### PR TITLE
Update version number for notices and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Gradle:
 
 ```gradle
-compile 'io.airbrake:javabrake:0.1.5'
+compile 'io.airbrake:javabrake:0.1.6'
 ```
 
 Maven:
@@ -18,14 +18,14 @@ Maven:
 <dependency>
   <groupId>io.airbrake</groupId>
   <artifactId>javabrake</artifactId>
-  <version>0.1.5</version>
+  <version>0.1.6</version>
 </dependency>
 ```
 
 Ivy:
 
 ```xml
-<dependency org='io.airbrake' name='javabrake' rev='0.1.5'>
+<dependency org='io.airbrake' name='javabrake' rev='0.1.6'>
   <artifact name='javabrake' ext='pom'></artifact>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.airbrake</groupId>
   <artifactId>javabrake</artifactId>
-  <version>0.1.4</version>
+  <version>0.1.6</version>
   <inceptionYear>2017</inceptionYear>
   <licenses>
     <license>

--- a/src/main/java/Notice.java
+++ b/src/main/java/Notice.java
@@ -14,7 +14,7 @@ public class Notice {
   static {
     notifierInfo = new HashMap<>();
     notifierInfo.put("name", "javabrake");
-    notifierInfo.put("version", "0.1.4");
+    notifierInfo.put("version", "0.1.6");
     notifierInfo.put("url", "https://github.com/airbrake/javabrake");
   }
 


### PR DESCRIPTION
- Updates javabrake version number that's attached to notices to `0.1.6`
- Updates javabrake version number mentioned in readme to `0.1.6`