### PR TITLE
Handling a new map passed in

### DIFF
--- a/src/main/java/Truncator.java
+++ b/src/main/java/Truncator.java
@@ -59,6 +59,9 @@ class Truncator {
 
   Map<String, Object> truncateMap(Map<String, Object> map, int depth) {
     Map<String, Object> dst = new HashMap<>();
+    if (map == null) {
+      return dst;
+    }
     int i = 0;
     for (Map.Entry<String, Object> entry : map.entrySet()) {
       if (i >= this.maxMapSize) {

--- a/src/test/java/TruncatorTest.java
+++ b/src/test/java/TruncatorTest.java
@@ -103,4 +103,11 @@ public class TruncatorTest {
     String s = (String) submap2.get("submap3");
     assertEquals("[Truncated Map]", s);
   }
+
+  @Test
+  public void testTruncateNull() {
+    Truncator truncator = new Truncator(0);
+    Map<String, Object> output = truncator.truncateMap(null, 0);
+    assertEquals(new HashMap<String, Object>(), output);
+  }
 }


### PR DESCRIPTION
This is to prevent a null from being passed in the `truncateMap` method. We are using `javabrake` with `log4javabrake2` (configured as a slf4j2 appender).

The stacktrace leading to this edge case looks like this:
```
2019-06-05 12:04:15,275 MyClass-0 ERROR An exception occurred processing Appender Airbrake java.lang.NullPointerException
 at io.airbrake.javabrake.Truncator.truncateMap(Truncator.java:63)
 at io.airbrake.javabrake.OkSender.noticeJson(OkSender.java:76)
 at io.airbrake.javabrake.OkSender.buildRequest(OkSender.java:53)
 at io.airbrake.javabrake.OkAsyncSender.send(OkAsyncSender.java:44)
 at io.airbrake.javabrake.Notifier.send(Notifier.java:68)
 at io.airbrake.log4javabrake2.AirbrakeAppender.send(AirbrakeAppender.java:120)
 at io.airbrake.log4javabrake2.AirbrakeAppender.append(AirbrakeAppender.java:53)
 at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:156)
 at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:129)
 at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:120)
 at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:84)
 at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:464)
 at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:448)
 at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:431)
 at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:406)
 at org.apache.logging.log4j.core.config.AwaitCompletionReliabilityStrategy.log(AwaitCompletionReliabilityStrategy.java:63)
 at org.apache.logging.log4j.core.Logger.logMessage(Logger.java:146)
 at org.apache.logging.log4j.spi.AbstractLogger.tryLogMessage(AbstractLogger.java:2170)
 at org.apache.logging.log4j.spi.AbstractLogger.logMessageTrackRecursion(AbstractLogger.java:2125)
 at org.apache.logging.log4j.spi.AbstractLogger.logMessageSafely(AbstractLogger.java:2108)
 at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:2013)
 at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:1882)
 at org.apache.logging.slf4j.Log4jLogger.error(Log4jLogger.java:314)
...
```