### PR TITLE
Added the Config class and changed the way a notifier is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ Configuration:
 
 ```java
 import io.airbrake.javabrake.Notifier;
+import io.airbrake.javabrake.Config;
 
-int projectId = 12345;
-String projectKey = "FIXME";
-Notifier notifier = new Notifier(projectId, projectKey);
+Config config = new Config();
+config.projectId = 12345;
+config.projectKey = "FIXME";
+Notifier notifier = new Notifier(config);
 
 notifier.addFilter(
     (Notice notice) -> {

--- a/src/main/java/Config.java
+++ b/src/main/java/Config.java
@@ -1,0 +1,6 @@
+package io.airbrake.javabrake;
+
+public class Config {
+  int projectId;
+  String projectKey;
+}

--- a/src/main/java/Notifier.java
+++ b/src/main/java/Notifier.java
@@ -17,10 +17,12 @@ public class Notifier {
   final List<NoticeFilter> filters = new ArrayList<>();
 
   /**
-   * @param projectId Airbrake project id
-   * @param projectKey Airbrake project key
+   * @param config Configures the notifier
    */
-  public Notifier(int projectId, String projectKey) {
+  public Notifier(Config config) {
+    int projectId = config.projectId;
+    String projectKey = config.projectKey;
+
     this.asyncSender = new OkAsyncSender(projectId, projectKey);
     this.syncSender = new OkSyncSender(projectId, projectKey);
 

--- a/src/test/java/NotifierTest.java
+++ b/src/test/java/NotifierTest.java
@@ -11,7 +11,7 @@ import org.junit.Rule;
 public class NotifierTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule();
 
-  Notifier notifier = new Notifier(0, "");
+  Notifier notifier = new Notifier(new Config());
   Throwable exc = new IOException("hello from Java");
 
   @Test


### PR DESCRIPTION
At the moment Javabrake doesn't support configuration. We can only configure
`projectKey` and `projectId`. We are planning to add notifier config support and
we need a few new options. Thus, we have to improved our current mechanism, so
that we can add more options.

This is a breaking change.