### PR TITLE
build.gradle: use maven-publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'com.jfrog.bintray' version '1.7.3'
 }
 
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'java-library'
 apply plugin: 'io.codearte.nexus-staging'
 


### PR DESCRIPTION
Eliminates the following warning:

> The maven plugin has been deprecated. This is scheduled to be removed in
> Gradle 7.0. Please use the maven-publish plugin instead. Consult the upgrading
> guide for further information:
> https://docs.gradle.org/6.8.3/userguide/upgrading_version_5.html#legacy_publication_system_is_deprecated_and_replaced_with_the_publish_plugins