### PR TITLE
build.gradle: switch to Gradle 7 compatible directives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,11 +30,11 @@ repositories {
 }
 
 dependencies {
-    compile 'com.squareup.okhttp3:okhttp:3.8.1'
-    compile 'com.google.code.gson:gson:1.7.2'
-    compile 'com.google.code.findbugs:jsr305:3.0.2'
+    implementation 'com.squareup.okhttp3:okhttp:3.8.1'
+    implementation 'com.google.code.gson:gson:1.7.2'
+    api 'com.google.code.findbugs:jsr305:3.0.2'
 
-    testCompile 'com.github.tomakehurst:wiremock:2.7.1'
+    testImplementation 'com.github.tomakehurst:wiremock:2.7.1'
 
     testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
Eliminates the following warnings:

> The compile configuration has been deprecated for dependency declaration. This
> will fail with an error in Gradle 7.0. Please use the implementation or api
> configuration instead.

> The testCompile configuration has been deprecated for dependency
> declaration. This will fail with an error in Gradle 7.0. Please use the
> testImplementation configuration instead.