### PR TITLE
build.gradle: bump 'com.jfrog.bintray' to version '1.8.5'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.jfrog.bintray' version '1.7.3'
+    id 'com.jfrog.bintray' version '1.8.5'
 }
 
 apply plugin: 'maven-publish'


### PR DESCRIPTION
This eliminates a bunch of warnings related to Gradle 7.0 but not all of
them. This also unblocks (but not fully) the way for releasing Javabrake as with
this version it prints a sensible error message (whereas the current version
fails silently).