### PR TITLE
PollTask: print bad payload and add better error handling

### DIFF
--- a/src/main/java/PollTask.java
+++ b/src/main/java/PollTask.java
@@ -62,14 +62,17 @@ class PollTask extends TimerTask {
     } catch(IOException e) {
       System.out.println(e.getMessage());
       e.printStackTrace();
+      return;
     }
 
     try {
       RemoteConfigJSON json_data = gson.fromJson(response, RemoteConfigJSON.class);
       this.data.merge(json_data);
     } catch(JsonSyntaxException e) {
+      System.out.printf("parse error on: %s\n", response);
       System.out.println(e.getMessage());
       e.printStackTrace();
+      return;
     }
 
     this.setErrorHost(this.data);


### PR DESCRIPTION
Addresses https://github.com/airbrake/javabrake/issues/49#issuecomment-821052550

If the HTTP request failed, we shouldn't continue execution. Otherwise there
will be a parse error since `response` is always `null`.