### PR TITLE
GSON upgrade and illegal reflective fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 
 dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.8.1'
-    implementation 'com.google.code.gson:gson:1.7.2'
+    implementation 'com.google.code.gson:gson:2.8.6'
     api 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'com.github.tomakehurst:wiremock:2.7.1'

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>1.7.2</version>
+      <version>2.8.6</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/Notice.java
+++ b/src/main/java/Notice.java
@@ -20,8 +20,10 @@ public class Notice {
 
   public String id;
   public String url;
+  /** Marked transient so gson will ignore this field during serialization **/
+  /** https://github.com/google/gson/blob/master/UserGuide.md#java-modifier-exclusion **/
   /** Exception occurred reporting this Notice. */
-  public Throwable exception;
+  public transient Throwable exception;
 
   public List<NoticeError> errors;
   @Nullable public Map<String, Object> context;

--- a/src/main/java/OkSender.java
+++ b/src/main/java/OkSender.java
@@ -4,9 +4,15 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.TimeUnit;
 import java.io.Reader;
+import java.lang.Throwable;
+import java.lang.reflect.Type;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonParseException;
 
 import okhttp3.MediaType;
@@ -20,7 +26,16 @@ public class OkSender {
   static final int maxNoticeSize = 64000;
   static final MediaType JSONType = MediaType.parse("application/json");
 
-  static final Gson gson = new GsonBuilder().create();
+  static class ThrowableSerializer implements JsonSerializer<Throwable> {
+    @Override
+    public JsonElement serialize(Throwable src, Type typeOfSrc, JsonSerializationContext context) {
+      return new JsonPrimitive(src.toString());
+    }
+  }
+
+  static final Gson gson = new GsonBuilder()
+    .registerTypeAdapter(Throwable.class, new ThrowableSerializer())
+    .create();
   static OkHttpClient okhttp =
       new OkHttpClient.Builder()
           .connectTimeout(3000, TimeUnit.MILLISECONDS)

--- a/src/main/java/OkSender.java
+++ b/src/main/java/OkSender.java
@@ -4,15 +4,9 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.TimeUnit;
 import java.io.Reader;
-import java.lang.Throwable;
-import java.lang.reflect.Type;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSerializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonParseException;
 
 import okhttp3.MediaType;
@@ -26,16 +20,7 @@ public class OkSender {
   static final int maxNoticeSize = 64000;
   static final MediaType JSONType = MediaType.parse("application/json");
 
-  static class ThrowableSerializer implements JsonSerializer<Throwable> {
-    @Override
-    public JsonElement serialize(Throwable src, Type typeOfSrc, JsonSerializationContext context) {
-      return new JsonPrimitive(src.toString());
-    }
-  }
-
-  static final Gson gson = new GsonBuilder()
-    .registerTypeAdapter(Throwable.class, new ThrowableSerializer())
-    .create();
+  static final Gson gson = new GsonBuilder().create();
   static OkHttpClient okhttp =
       new OkHttpClient.Builder()
           .connectTimeout(3000, TimeUnit.MILLISECONDS)

--- a/src/test/java/NotifierTest.java
+++ b/src/test/java/NotifierTest.java
@@ -76,7 +76,7 @@ public class NotifierTest {
     Notice notice = this.notifier.reportSync(this.exc);
     assertNotNull(notice.exception);
     assertEquals(
-        "com.google.gson.JsonParseException: Expecting object found: \"<!DOCTYPE\"",
+        "com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $",
         notice.exception.toString());
   }
 


### PR DESCRIPTION
In this PR we upgrades the GSON dependency to the most current version and mark the `Notice`'s `Throwable exception` field as `transient` to avoid GSON serialization. The `exception` field isn't used in the notice payload sent to Airbrake and we already extract the type, message, and backtrace from it.


This was the error that was reported and seen in our [ci specs](https://github.com/airbrake/javabrake/runs/2405994493#step:4:156) previous to [this fix commit](https://github.com/airbrake/javabrake/commit/31f2c989251771d37ee20f4e29f2d054fa77a50d). we no longer see the illegal reflection warning in the [latest ci runs of the tests](https://github.com/airbrake/javabrake/runs/2412689982#step:4:81).

```
WARNING: Illegal reflective access by com.google.gson.internal.reflect.UnsafeReflectionAccessor (file:/home/runner/.gradle/caches/modules-2/files-2.1/com.google.code.gson/gson/2.8.6/9180733b7df8542621dc12e21e87557e8c99b8cb/gson-2.8.6.jar) to field java.lang.Throwable.detailMessage
WARNING: Please consider reporting this to the maintainers of com.google.gson.internal.reflect.UnsafeReflectionAccessor
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

Marking the Throwable being serialized as `transient` will cause gson to ignore this field during serialization https://github.com/google/gson/blob/master/UserGuide.md#java-modifier-exclusion

Based on what I read about `transient`, it makes sense that GSON ignores the field:
> `transient` is a Java keyword which marks a member variable not to be serialized when it is persisted to streams of bytes. When an object is transferred through the network, the object needs to be 'serialized'.
source: [wikibooks - Java Programming](https://en.wikibooks.org/wiki/Java_Programming/Keywords/transient)

closes #34 