### PR TITLE
Deprecate log4javabrake integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,6 @@ notifier.onReportedNotice(
     });
 ```
 
-## log4j integration
-
-See https://github.com/airbrake/log4javabrake
-
 ## log4j2 integration
 
 See https://github.com/airbrake/log4javabrake2


### PR DESCRIPTION
This integration has been deprecated since log4j V1 is EOL.