### PR TITLE
Release v0.2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [13, 14, 15]
+        java: [8, 11, 13, 14, 15]
 
     name: Java ${{ matrix.java }}
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java adoptopenjdk-8.0.312+7

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Javabrake is a Java notifier for Airbrake.
 Gradle:
 
 ```gradle
-implementation 'io.airbrake:javabrake:0.2.3'
+implementation 'io.airbrake:javabrake:0.2.4'
 ```
 
 Maven:
@@ -25,14 +25,14 @@ Maven:
 <dependency>
   <groupId>io.airbrake</groupId>
   <artifactId>javabrake</artifactId>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
 </dependency>
 ```
 
 Ivy:
 
 ```xml
-<dependency org='io.airbrake' name='javabrake' rev='0.2.3'>
+<dependency org='io.airbrake' name='javabrake' rev='0.2.4'>
   <artifact name='javabrake' ext='pom'></artifact>
 </dependency>
 ```
@@ -170,7 +170,21 @@ OkHttpClient httpClient =
 OkSender.setOkHttpClient(httpClient);
 ```
 
-## Build
+## Notifier release instrucitons
+
+### A note on Java version
+Make sure you build and release this notifier with open-jdk-8, one way to manage your local java version is using [asdf](https://asdf-vm.com). You can install this tool via homebrew:
+```
+brew install asdf
+```
+Then install open-jdk-8 and set it as JAVA home before running any of the `./gradlew` commands:
+```
+asdf plugin add java
+asdf install java adoptopenjdk-8.0.312+7
+export JAVA_HOME=$HOME/.asdf/installs/java/adoptopenjdk-8.0.312+7
+```
+
+### Build
 
 ```shell
 ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'java-library'
 apply plugin: 'io.codearte.nexus-staging'
 
 group = 'io.airbrake'
-version = '0.2.3'
+version = '0.2.4'
 
 if (project.hasProperty('signing.keyId')) {
   apply plugin: 'signing'

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.airbrake</groupId>
   <artifactId>javabrake</artifactId>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
   <inceptionYear>2017</inceptionYear>
   <licenses>
     <license>

--- a/src/main/java/Notice.java
+++ b/src/main/java/Notice.java
@@ -14,7 +14,7 @@ public class Notice {
   static {
     notifierInfo = new HashMap<>();
     notifierInfo.put("name", "javabrake");
-    notifierInfo.put("version", "0.2.3");
+    notifierInfo.put("version", "0.2.4");
     notifierInfo.put("url", "https://github.com/airbrake/javabrake");
   }
 


### PR DESCRIPTION
This updates the build instructions for use with java 8
Adds more info to the readme
Adds more java versions to run tests in github actions